### PR TITLE
2 create user context api for global auth state

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,20 @@
-import { useState } from 'react';
+// filepath: /Users/alexmatei/git/tessera/src/App.tsx
+import { useState, useContext } from 'react';
 import { BrowserRouter as Router, Route, Routes, Link } from 'react-router-dom';
 import reactLogo from './assets/react.svg';
 import viteLogo from '/vite.svg';
 import './App.css';
 import Home from './pages/Home';
 import About from './pages/About';
+import { UserContext } from './UserContext';
 
 function App() {
   const [count, setCount] = useState(0);
+  const userContext = useContext(UserContext);
+  if (!userContext) {
+    return <div>Error: UserContext is not provided</div>;
+  }
+  const { user, login, logout } = userContext;
 
   return (
     <Router>
@@ -48,6 +55,18 @@ function App() {
       <p className="read-the-docs">
         Click on the Vite and React logos to learn more
       </p>
+      <div>
+        {user ? (
+          <div>
+            <p>Welcome, {user.name}</p>
+            <button onClick={logout}>Logout</button>
+          </div>
+        ) : (
+          <button onClick={() => login({ id: '1', name: 'John Doe', email: 'john@example.com' })}>
+            Login
+          </button>
+        )}
+      </div>
     </Router>
   );
 }

--- a/src/UserContext.tsx
+++ b/src/UserContext.tsx
@@ -1,0 +1,45 @@
+import React, { createContext, useState, useEffect, ReactNode } from 'react';
+
+interface User {
+  id: string;
+  name: string;
+  email: string;
+}
+
+interface UserContextType {
+  user: User | null;
+  login: (userData: User) => void;
+  logout: () => void;
+}
+
+const UserContext = createContext<UserContextType | undefined>(undefined);
+
+const UserProvider = ({ children }: { children: ReactNode }) => {
+  const [user, setUser] = useState<User | null>(null);
+
+  useEffect(() => {
+    // Check if user data is stored in localStorage
+    const storedUser = localStorage.getItem('user');
+    if (storedUser) {
+      setUser(JSON.parse(storedUser));
+    }
+  }, []);
+
+  const login = (userData: User) => {
+    setUser(userData);
+    localStorage.setItem('user', JSON.stringify(userData));
+  };
+
+  const logout = () => {
+    setUser(null);
+    localStorage.removeItem('user');
+  };
+
+  return (
+    <UserContext.Provider value={{ user, login, logout }}>
+      {children}
+    </UserContext.Provider>
+  );
+};
+
+export { UserContext, UserProvider };

--- a/src/UserContext.tsx
+++ b/src/UserContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useState, useEffect, ReactNode } from 'react';
+import { createContext, useState, useEffect, ReactNode } from 'react';
 
 interface User {
   id: string;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,13 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.tsx'
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import './index.css';
+import App from './App';
+import { UserProvider } from './UserContext';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
-  </StrictMode>,
-)
+    <UserProvider>
+      <App />
+    </UserProvider>
+  </StrictMode>
+);


### PR DESCRIPTION
closes #2 

Adds user context to manage global authorization state (user is logged in or logged out).

To test:

1. Run`npm run dev`
2. Open site in a browser and check the init state (if login button present -> logged out, else logged in).
3. Click log in and check if you see the welcome message.
4. Check localStorage: Open the browser's developer tools (usually by pressing F12 or Ctrl+Shift+I), go to the "Application" tab, and check the "Local Storage" section. You should see an entry for the user data under the key "user".
5. Click the "Logout" button to log out the user. The welcome message should disappear, and the "Login" button should reappear. The user data should also be removed from localStorage.
6. Refresh the page to ensure that the authentication state persists across page reloads. If the user was logged in before the refresh, they should still be logged in after the refresh. If the user was logged out, they should still be logged out after the refresh.